### PR TITLE
Use userId instead of userEmail for graph API calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "outlook-meetings-scheduler",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "outlook-meetings-scheduler",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "@azure/identity": "^4.12.0",

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -12,14 +12,14 @@ export default class Graph {
         this.authManager = authManager;
     }
 
-    async createEvent(event: Event, userEmail: string): Promise<any> {
+    async createEvent(event: Event, userId: string): Promise<any> {
         const client: Client | null = await this.getClient();
 
         if (client) {
             logger.progress("⌛ Creating event...");
             try {
                 const result: any = await client
-                    .api(`/users/${userEmail}/calendar/events`)
+                    .api(`/users/${userId}/calendar/events`)
                     .post(event);
 
                 if (result) {
@@ -36,7 +36,7 @@ export default class Graph {
         return null;
     };
 
-    async searchPeople(searchTerm: string, userEmail: string): Promise<any> {
+    async searchPeople(searchTerm: string, userId: string): Promise<any> {
         const client: Client | null = await this.getClient();
 
         if (client) {
@@ -44,7 +44,7 @@ export default class Graph {
             try {
                 // Try the /people endpoint first as it's most likely to have recent contacts
                 const peopleResult = await client
-                    .api(`/users/${userEmail}/people`)
+                    .api(`/users/${userId}/people`)
                     .search(`"${searchTerm}"`)
                     .get();
 
@@ -77,14 +77,14 @@ export default class Graph {
         return null;
     };
 
-    async getEvent(eventId: string, userEmail: string): Promise<any> {
+    async getEvent(eventId: string, userId: string): Promise<any> {
         const client: Client | null = await this.getClient();
 
         if (client) {
             logger.progress(`⌛ Getting event with ID ${eventId}...`);
             try {
                 const result: any = await client
-                    .api(`/users/${userEmail}/calendar/events/${eventId}`)
+                    .api(`/users/${userId}/calendar/events/${eventId}`)
                     .get();
 
                 if (result) {
@@ -101,14 +101,14 @@ export default class Graph {
         return null;
     };
 
-    async updateEvent(eventId: string, eventUpdates: Partial<Event>, userEmail: string): Promise<any> {
+    async updateEvent(eventId: string, eventUpdates: Partial<Event>, userId: string): Promise<any> {
         const client: Client | null = await this.getClient();
 
         if (client) {
             logger.progress(`⌛ Updating event with ID ${eventId}...`);
             try {
                 const result: any = await client
-                    .api(`/users/${userEmail}/calendar/events/${eventId}`)
+                    .api(`/users/${userId}/calendar/events/${eventId}`)
                     .update(eventUpdates);
 
                 if (result) {
@@ -125,14 +125,14 @@ export default class Graph {
         return null;
     };
 
-    async deleteEvent(eventId: string, userEmail: string): Promise<boolean> {
+    async deleteEvent(eventId: string, userId: string): Promise<boolean> {
         const client: Client | null = await this.getClient();
 
         if (client) {
             logger.progress(`⌛ Deleting event with ID ${eventId}...`);
             try {
                 await client
-                    .api(`/users/${userEmail}/calendar/events/${eventId}`)
+                    .api(`/users/${userId}/calendar/events/${eventId}`)
                     .delete();
 
                 logger.info("✅ Event deleted");
@@ -145,13 +145,13 @@ export default class Graph {
         return false;
     };
 
-    async listEvents(userEmail: string, params: {startDateTime?: string, endDateTime?: string, filter?: string, top?: number, subject?: string} = {}): Promise<any> {
+    async listEvents(userId: string, params: {startDateTime?: string, endDateTime?: string, filter?: string, top?: number, subject?: string} = {}): Promise<any> {
         const client: Client | null = await this.getClient();
 
         if (client) {
             logger.progress("⌛ Listing calendar events...");
             try {
-                let request = client.api(`/users/${userEmail}/calendar/events`);
+                let request = client.api(`/users/${userId}/calendar/events`);
                 
                 // Apply query parameters if provided
                 if (params.startDateTime && params.endDateTime) {

--- a/src/tools/event-create.ts
+++ b/src/tools/event-create.ts
@@ -22,19 +22,19 @@ export function registerEventCreateTools(server: McpServer): void {
       timeZone: z.string().optional().describe("Time zone for the event. Defaults to GMT Standard Time"),
     },
     async ({ subject, body, start, end, timeZone = "GMT Standard Time" }) => {
-      const { graph, userEmail, authError } = await getGraphConfig();
+      const { graph, userEmail, userId, authError } = await getGraphConfig();
 
       if (authError) {
         return {
           content: [{ type: "text", text: `🔐 Authentication Required\n\n${authError}\n\nPlease complete the authentication and try again.` }]
         };
       }
-  
+
       // Calculate default times if not provided
       const nextDay: string = format(addBusinessDays(new Date(), 1), 'yyyy-MM-dd');
       const startTime: string = start ? start : `${nextDay}T12:00:00`;
       const endTime: string = end ? end : `${nextDay}T13:00:00`;
-  
+
       // Create the event object
       const event: Event = {
         subject,
@@ -51,9 +51,9 @@ export function registerEventCreateTools(server: McpServer): void {
           timeZone
         }
       };
-  
+
       // Call the Graph API to create the event
-      const result = await graph.createEvent(event, userEmail);
+      const result = await graph.createEvent(event, userId);
       
       if (!result) {
         return {
@@ -113,19 +113,19 @@ Event URL: ${eventUrl}
       ).describe("List of attendees for the event")
     },
     async ({ subject, body, start, end, timeZone = "GMT Standard Time", location, attendees }) => {
-      const { graph, userEmail, authError } = await getGraphConfig();
+      const { graph, userEmail, userId, authError } = await getGraphConfig();
 
       if (authError) {
         return {
           content: [{ type: "text", text: `🔐 Authentication Required\n\n${authError}\n\nPlease complete the authentication and try again.` }]
         };
       }
-  
+
       // Calculate default times if not provided
       const nextDay: string = format(addBusinessDays(new Date(), 1), 'yyyy-MM-dd');
       const startTime: string = start ? start : `${nextDay}T12:00:00`;
       const endTime: string = end ? end : `${nextDay}T13:00:00`;
-  
+
       // Format attendees for the event
       const formattedAttendees: Attendee[] = attendees.map((attendee: any) => ({
         emailAddress: {
@@ -159,9 +159,9 @@ Event URL: ${eventUrl}
           displayName: location
         };
       }
-  
+
       // Call the Graph API to create the event
-      const result = await graph.createEvent(event, userEmail);
+      const result = await graph.createEvent(event, userId);
       
       if (!result) {
         return {

--- a/src/tools/event-delete.ts
+++ b/src/tools/event-delete.ts
@@ -16,17 +16,17 @@ export function registerEventDeleteTools(server: McpServer): void {
       eventId: z.string().describe("ID of the event to delete"),
     },
     async ({ eventId }) => {
-      const { graph, userEmail, authError } = await getGraphConfig();
+      const { graph, userId, authError } = await getGraphConfig();
 
       if (authError) {
         return {
           content: [{ type: "text", text: `🔐 Authentication Required\n\n${authError}\n\nPlease complete the authentication and try again.` }]
         };
       }
-  
+
       // First get the event details to confirm what's being deleted
-      const event = await graph.getEvent(eventId, userEmail);
-      
+      const event = await graph.getEvent(eventId, userId);
+
       if (!event) {
         return {
           content: [
@@ -37,9 +37,9 @@ export function registerEventDeleteTools(server: McpServer): void {
           ],
         };
       }
-      
+
       // Delete the event
-      const success = await graph.deleteEvent(eventId, userEmail);
+      const success = await graph.deleteEvent(eventId, userId);
       
       if (!success) {
         return {

--- a/src/tools/event-read.ts
+++ b/src/tools/event-read.ts
@@ -16,16 +16,16 @@ export function registerEventReadTools(server: McpServer): void {
       eventId: z.string().describe("ID of the event to retrieve"),
     },
     async ({ eventId }) => {
-      const { graph, userEmail, authError } = await getGraphConfig();
+      const { graph, userEmail, userId, authError } = await getGraphConfig();
 
       if (authError) {
         return {
           content: [{ type: "text", text: `🔐 Authentication Required\n\n${authError}\n\nPlease complete the authentication and try again.` }]
         };
       }
-  
+
       // Retrieve the event
-      const event = await graph.getEvent(eventId, userEmail);
+      const event = await graph.getEvent(eventId, userId);
       
       if (!event) {
         return {
@@ -94,14 +94,14 @@ Event URL: ${eventUrl}
       maxResults: z.number().optional().describe("Maximum number of events to return"),
     },
     async ({ subject, startDate, endDate, maxResults }) => {
-      const { graph, userEmail, authError } = await getGraphConfig();
+      const { graph, userId, authError } = await getGraphConfig();
 
       if (authError) {
         return {
           content: [{ type: "text", text: `🔐 Authentication Required\n\n${authError}\n\nPlease complete the authentication and try again.` }]
         };
       }
-  
+
       // Set up parameters for listing events
       const params: any = {};
       if (subject) {
@@ -116,9 +116,9 @@ Event URL: ${eventUrl}
       if (maxResults) {
         params.top = maxResults;
       }
-  
+
       // Call the Graph API to list events
-      const result = await graph.listEvents(userEmail, params);
+      const result = await graph.listEvents(userId, params);
       
       if (!result || !result.value) {
         return {

--- a/src/tools/event-update.ts
+++ b/src/tools/event-update.ts
@@ -31,7 +31,7 @@ export function registerEventUpdateTools(server: McpServer): void {
       ).optional().describe("List of attendees to add or update for the event"),
     },
     async ({ eventId, subject, body, start, end, timeZone, location, attendees }) => {
-      const { graph, userEmail, authError } = await getGraphConfig();
+      const { graph, userId, authError } = await getGraphConfig();
 
       if (authError) {
         return {
@@ -76,7 +76,7 @@ export function registerEventUpdateTools(server: McpServer): void {
       // Handle attendees if provided
       if (attendees && attendees.length > 0) {
         // First get the current event to merge with existing attendees
-        const currentEvent = await graph.getEvent(eventId, userEmail);
+        const currentEvent = await graph.getEvent(eventId, userId);
         
         if (!currentEvent || !currentEvent.attendees) {
           // If no current attendees, just use the new ones
@@ -115,8 +115,8 @@ export function registerEventUpdateTools(server: McpServer): void {
       }
   
       // First get the current event to show what's being updated
-      const currentEvent = await graph.getEvent(eventId, userEmail);
-      
+      const currentEvent = await graph.getEvent(eventId, userId);
+
       if (!currentEvent) {
         return {
           content: [
@@ -127,9 +127,9 @@ export function registerEventUpdateTools(server: McpServer): void {
           ],
         };
       }
-      
+
       // Call the Graph API to update the event
-      const result = await graph.updateEvent(eventId, eventUpdates, userEmail);
+      const result = await graph.updateEvent(eventId, eventUpdates, userId);
       
       if (!result) {
         return {
@@ -185,16 +185,16 @@ Event URL: ${eventUrl}
       ).optional().describe("List of email addresses to remove from the event"),
     },
     async ({ eventId, addAttendees, removeAttendees }) => {
-      const { graph, userEmail, authError } = await getGraphConfig();
+      const { graph, userId, authError } = await getGraphConfig();
 
       if (authError) {
         return {
           content: [{ type: "text", text: `🔐 Authentication Required\n\n${authError}\n\nPlease complete the authentication and try again.` }]
         };
       }
-  
+
       // First get the current event to get existing attendees
-      const currentEvent = await graph.getEvent(eventId, userEmail);
+      const currentEvent = await graph.getEvent(eventId, userId);
       
       if (!currentEvent) {
         return {
@@ -264,9 +264,9 @@ Event URL: ${eventUrl}
         const eventUpdates: Partial<Event> = {
           attendees: updatedAttendees
         };
-        
+
         // Call the Graph API to update the event
-        const result = await graph.updateEvent(eventId, eventUpdates, userEmail);
+        const result = await graph.updateEvent(eventId, eventUpdates, userId);
         
         if (!result) {
           return {

--- a/src/tools/people.ts
+++ b/src/tools/people.ts
@@ -15,7 +15,7 @@ export function registerPeopleTools(server: McpServer): void {
       name: z.string().describe("Name or partial name of the person to find"),
     },
     async ({ name }) => {
-      const { graph, userEmail, authError } = await getGraphConfig();
+      const { graph, userId, authError } = await getGraphConfig();
 
       // Check for authentication errors
       if (authError) {
@@ -30,7 +30,7 @@ export function registerPeopleTools(server: McpServer): void {
       }
 
       // Search for the person by name
-      const people = await graph.searchPeople(name, userEmail);
+      const people = await graph.searchPeople(name, userId);
       
       if (!people) {
         return {

--- a/src/utils/graph-config.ts
+++ b/src/utils/graph-config.ts
@@ -113,35 +113,47 @@ async function initializeAuth(): Promise<{ authManager: AuthManager; graph: Grap
 export async function getGraphConfig() {
   const authModeStr = process.env.AUTH_MODE || "interactive";
   const authMode = authModeStr as AuthMode;
-  
+
   // For client_credentials mode, USER_EMAIL is required
   // For interactive mode, we'll get the email from the authenticated user
   let userEmail = process.env.USER_EMAIL || "";
+  let userId = process.env.USER_ID || "";
   
   try {
     const { authManager, graph } = await initializeAuth();
     
-    // If interactive mode and no USER_EMAIL specified, get it from the authenticated user
-    if (authMode === AuthMode.Interactive && !userEmail) {
+    // If interactive mode and no USER_ID/USER_EMAIL specified, get them from the authenticated user
+    if (authMode === AuthMode.Interactive && (!userEmail || !userId)) {
       try {
         // Get the authenticated user's profile
         const credential = authManager.getAzureCredential();
         const token = await credential.getToken("https://graph.microsoft.com/.default");
-        
+
         if (token) {
           // Create a temporary client to get user info
           const Client = (await import("@microsoft/microsoft-graph-client")).Client;
           const tempClient = Client.initWithMiddleware({
             authProvider: authManager.getGraphAuthProvider()
           });
-          
-          const user = await tempClient.api('/me').select('mail,userPrincipalName').get();
-          userEmail = user.mail || user.userPrincipalName;
-          logger.info(`✅ Using authenticated user email: ${userEmail}`);
+
+          const user = await tempClient.api('/me').select('id,mail,userPrincipalName,otherMails').get();
+          logger.info(`User profile response: ${JSON.stringify(user)}`);
+
+          if (!userId) {
+            userId = user.id;
+            logger.info(`✅ Using authenticated user ID: ${userId}`);
+          }
+
+          if (!userEmail) {
+            userEmail = user.mail
+              || (user.otherMails && user.otherMails.length > 0 ? user.otherMails[0] : null)
+              || user.userPrincipalName;
+            logger.info(`✅ Using authenticated user email: ${userEmail}`);
+          }
         }
       } catch (error: any) {
-        logger.error("Failed to get authenticated user email", error);
-        throw new Error("Failed to determine user email. Please set USER_EMAIL environment variable.");
+        logger.error("Failed to get authenticated user profile", error);
+        throw new Error("Failed to determine user ID/email. Please set USER_ID and USER_EMAIL environment variables.");
       }
     }
     
@@ -150,13 +162,14 @@ export async function getGraphConfig() {
       throw new Error("USER_EMAIL environment variable is required for client_credentials mode");
     }
     
-    return { graph, userEmail, authManager, authError: null };
+    return { graph, userEmail, userId, authManager, authError: null };
   } catch (error: any) {
     // Return the error so tools can handle it gracefully
-    return { 
-      graph: null as any, 
-      userEmail: userEmail || "", 
-      authManager: null as any, 
+    return {
+      graph: null as any,
+      userEmail: userEmail || "",
+      userId: userId || "",
+      authManager: null as any,
       authError: error.message || String(error)
     };
   }


### PR DESCRIPTION
Problem: I kept getting 401 errors when trying different personal emails via USER_EMAIL and parsing different fields from the `/me` call. So I switched to adding the `?id` field to `/me` and use that for all the API calls.

Result: Meh, I'm still getting 401 errors...